### PR TITLE
Add basic enterprise app structure with core and shared modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.angular/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,17 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`.
 
-## Code scaffolding
+## Project structure
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+The application follows a feature-based architecture:
+
+- **core** – singleton services and layout components (e.g. `HeaderComponent`).
+- **shared** – reusable UI components such as buttons.
+- **features** – lazy loaded modules (e.g. `dashboard`, `employee`).
+
+Global SCSS files under `src/assets/scss` define variables, mixins and utilities used across the app. Bootstrap is imported for basic styling.
 
 ## Build
 
@@ -18,10 +24,3 @@ Run `ng build` to build the project. The build artifacts will be stored in the `
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
 
-## Running end-to-end tests
-
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
-
-## Further help
-
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,7 +1,11 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-const routes: Routes = [{ path: 'employee', loadChildren: () => import('./features/employee/employee.module').then(m => m.EmployeeModule) }];
+const routes: Routes = [
+  { path: '', loadChildren: () => import('./features/dashboard/dashboard.module').then(m => m.DashboardModule) },
+  { path: 'employee', loadChildren: () => import('./features/employee/employee.module').then(m => m.EmployeeModule) },
+  { path: '**', redirectTo: '' }
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,1 +1,4 @@
-<router-outlet></router-outlet>
+<app-header></app-header>
+<div class="main-container">
+  <router-outlet></router-outlet>
+</div>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { CoreModule } from './core/core.module';
 
 @NgModule({
   declarations: [
@@ -10,7 +11,8 @@ import { AppComponent } from './app.component';
   ],
   imports: [
     BrowserModule,
-    AppRoutingModule
+    AppRoutingModule,
+    CoreModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HeaderComponent } from './header/header.component';
+
+@NgModule({
+  declarations: [HeaderComponent],
+  imports: [CommonModule],
+  exports: [HeaderComponent]
+})
+export class CoreModule { }

--- a/src/app/core/header/header.component.html
+++ b/src/app/core/header/header.component.html
@@ -1,0 +1,18 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" routerLink="/">EnterpriseApp</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+        <li class="nav-item">
+          <a class="nav-link" routerLink="/">Dashboard</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" routerLink="/employee">Employees</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/src/app/core/header/header.component.scss
+++ b/src/app/core/header/header.component.scss
@@ -1,0 +1,3 @@
+.navbar-brand {
+  font-weight: bold;
+}

--- a/src/app/core/header/header.component.ts
+++ b/src/app/core/header/header.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-header',
+  templateUrl: './header.component.html',
+  styleUrls: ['./header.component.scss']
+})
+export class HeaderComponent { }

--- a/src/app/features/dashboard/dashboard-routing.module.ts
+++ b/src/app/features/dashboard/dashboard-routing.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+
+const routes: Routes = [{ path: '', component: DashboardComponent }];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class DashboardRoutingModule { }

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -1,0 +1,4 @@
+<div class="p-4 text-center">
+  <h1>Welcome to EnterpriseApp</h1>
+  <p>This dashboard serves as the landing page.</p>
+</div>

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent { }

--- a/src/app/features/dashboard/dashboard.module.ts
+++ b/src/app/features/dashboard/dashboard.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DashboardRoutingModule } from './dashboard-routing.module';
+import { DashboardComponent } from './dashboard.component';
+
+@NgModule({
+  declarations: [DashboardComponent],
+  imports: [CommonModule, DashboardRoutingModule]
+})
+export class DashboardModule { }

--- a/src/app/features/employee/components/employee-card/employee-card.component.html
+++ b/src/app/features/employee/components/employee-card/employee-card.component.html
@@ -1,1 +1,8 @@
-<p>employee-card works!</p>
+<div class="card h-100">
+  <div class="card-body">
+    <h5 class="card-title">{{ employee.name }}</h5>
+    <p class="card-text mb-1"><strong>Position:</strong> {{ employee.position }}</p>
+    <p class="card-text"><strong>Department:</strong> {{ employee.department }}</p>
+    <app-button class="mt-1" label="View" type="button"></app-button>
+  </div>
+</div>

--- a/src/app/features/employee/components/employee-card/employee-card.component.scss
+++ b/src/app/features/employee/components/employee-card/employee-card.component.scss
@@ -1,0 +1,5 @@
+@import 'src/assets/scss/mixins';
+
+.card {
+  @include shadow-sm;
+}

--- a/src/app/features/employee/components/employee-card/employee-card.component.ts
+++ b/src/app/features/employee/components/employee-card/employee-card.component.ts
@@ -1,15 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { Employee } from '../../services/employee.service';
 
 @Component({
   selector: 'app-employee-card',
   templateUrl: './employee-card.component.html',
   styleUrls: ['./employee-card.component.scss']
 })
-export class EmployeeCardComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
+export class EmployeeCardComponent {
+  @Input() employee!: Employee;
 }

--- a/src/app/features/employee/employee.module.ts
+++ b/src/app/features/employee/employee.module.ts
@@ -5,6 +5,7 @@ import { EmployeeRoutingModule } from './employee-routing.module';
 import { EmployeeComponent } from './employee.component';
 import { EmployeeListComponent } from './pages/employee-list/employee-list.component';
 import { EmployeeCardComponent } from './components/employee-card/employee-card.component';
+import { SharedModule } from '../../shared/shared.module';
 
 
 @NgModule({
@@ -15,7 +16,8 @@ import { EmployeeCardComponent } from './components/employee-card/employee-card.
   ],
   imports: [
     CommonModule,
-    EmployeeRoutingModule
+    EmployeeRoutingModule,
+    SharedModule
   ]
 })
 export class EmployeeModule { }

--- a/src/app/features/employee/pages/employee-list/employee-list.component.html
+++ b/src/app/features/employee/pages/employee-list/employee-list.component.html
@@ -1,1 +1,5 @@
-<p>employee-list works!</p>
+<div class="row g-3">
+  <div class="col-md-4" *ngFor="let emp of employees">
+    <app-employee-card [employee]="emp"></app-employee-card>
+  </div>
+</div>

--- a/src/app/features/employee/pages/employee-list/employee-list.component.ts
+++ b/src/app/features/employee/pages/employee-list/employee-list.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Employee, EmployeeService } from '../../services/employee.service';
 
 @Component({
   selector: 'app-employee-list',
@@ -6,10 +7,11 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./employee-list.component.scss']
 })
 export class EmployeeListComponent implements OnInit {
+  employees: Employee[] = [];
 
-  constructor() { }
+  constructor(private employeeService: EmployeeService) { }
 
   ngOnInit(): void {
+    this.employeeService.getEmployees().subscribe(data => this.employees = data);
   }
-
 }

--- a/src/app/features/employee/services/employee.service.ts
+++ b/src/app/features/employee/services/employee.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+
+export interface Employee {
+  id: number;
+  name: string;
+  position: string;
+  department: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class EmployeeService {
+  private employees: Employee[] = [
+    { id: 1, name: 'John Doe', position: 'Developer', department: 'Engineering' },
+    { id: 2, name: 'Jane Smith', position: 'Designer', department: 'UX' },
+    { id: 3, name: 'Bob Johnson', position: 'Manager', department: 'HR' }
+  ];
+
+  getEmployees(): Observable<Employee[]> {
+    return of(this.employees);
+  }
+}

--- a/src/app/shared/components/button/button.component.html
+++ b/src/app/shared/components/button/button.component.html
@@ -1,0 +1,1 @@
+<button class="btn btn-primary" [attr.type]="type">{{ label }}</button>

--- a/src/app/shared/components/button/button.component.scss
+++ b/src/app/shared/components/button/button.component.scss
@@ -1,0 +1,1 @@
+/* Simple button wrapper for consistent styling */

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-button',
+  templateUrl: './button.component.html',
+  styleUrls: ['./button.component.scss']
+})
+export class ButtonComponent {
+  @Input() label = 'Button';
+  @Input() type: 'button' | 'submit' = 'button';
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ButtonComponent } from './components/button/button.component';
+
+@NgModule({
+  declarations: [ButtonComponent],
+  imports: [CommonModule],
+  exports: [ButtonComponent]
+})
+export class SharedModule { }

--- a/src/assets/scss/components.scss
+++ b/src/assets/scss/components.scss
@@ -1,0 +1,1 @@
+// component specific global styles

--- a/src/assets/scss/layout.scss
+++ b/src/assets/scss/layout.scss
@@ -1,0 +1,3 @@
+.main-container {
+  padding: $spacer;
+}

--- a/src/assets/scss/mixins.scss
+++ b/src/assets/scss/mixins.scss
@@ -1,0 +1,9 @@
+@mixin shadow-sm {
+  box-shadow: 0 .125rem .25rem rgba(0, 0, 0, .075);
+}
+
+@mixin flex-center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/assets/scss/utilities.scss
+++ b/src/assets/scss/utilities.scss
@@ -1,0 +1,3 @@
+.m-0 { margin: 0 !important; }
+.mt-1 { margin-top: $spacer * .25 !important; }
+.mb-1 { margin-bottom: $spacer * .25 !important; }

--- a/src/assets/scss/variables.scss
+++ b/src/assets/scss/variables.scss
@@ -1,0 +1,4 @@
+$primary-color: #0d6efd;
+$secondary-color: #6c757d;
+
+$spacer: 1rem;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,6 +1,7 @@
-/* You can add global styles to this file, and also import other style files */
-// src/styles.scss
+/* Global Styles */
 @import "assets/scss/variables";
 @import "assets/scss/mixins";
 @import "assets/scss/utilities";
+@import "assets/scss/layout";
+@import "assets/scss/components";
 @import "~bootstrap/scss/bootstrap";


### PR DESCRIPTION
## Summary
- create core module with header navigation
- add shared module with reusable button component
- implement dashboard module for home page
- provide employee service and display employee cards
- organize global SCSS with variables and mixins
- document project structure in README

## Testing
- `npm install`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6871ecb301bc8323bbe93c6f232cf238