### PR TITLE
Fix employee routing

### DIFF
--- a/src/app/features/employee/employee-routing.module.ts
+++ b/src/app/features/employee/employee-routing.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { EmployeeComponent } from './employee.component';
+import { EmployeeListComponent } from './pages/employee-list/employee-list.component';
 
-const routes: Routes = [{ path: '', component: EmployeeComponent }];
+const routes: Routes = [
+  { path: '', component: EmployeeListComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],


### PR DESCRIPTION
## Summary
- fix the employee module route so the EmployeeListComponent displays by default

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6872009abb508323ac67bfafa725a1ee